### PR TITLE
Add basic Bicep deployment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# azure-apim-appgw-configuration
+# Azure Cost Optimizer
+
+This project contains an initial scaffold for the **Azure Cost Optimizer** service. The goal is to build a small SaaS solution that analyzes Azure usage and highlights potential savings.
+
+## Project Structure
+
+- `frontend/` – React application (Vite) for the dashboard
+- `backend/` – FastAPI server providing cost analysis APIs
+- `infra/` – Bicep templates used to deploy the service
+
+## Getting Started
+
+1. Clone the repository
+2. Install dependencies for the backend and frontend
+   - `pip install fastapi uvicorn azure-identity azure-mgmt-costmanagement`
+3. Set the following environment variables so the backend can query Azure Cost Management APIs:
+   - `AZURE_TENANT_ID`
+   - `AZURE_CLIENT_ID`
+   - `AZURE_CLIENT_SECRET`
+   - `AZURE_SUBSCRIPTION_ID`
+4. Run the FastAPI server and start the React dev server
+
+This repository is only a starting point. Follow the project plan to implement Azure authentication, cost data collection, the insights engine, and the web dashboard.
+
+### API Endpoints
+
+- `GET /` – Health check returning a welcome message
+- `GET /costs` – Fetches basic cost data for the configured subscription
+
+## Deploying Infrastructure
+
+Run the following command with the Azure CLI to deploy the base resources defined in `infra/main.bicep`:
+
+```bash
+az deployment group create \
+  --resource-group <resource-group> \
+  --template-file infra/main.bicep
+```

--- a/backend/cost.py
+++ b/backend/cost.py
@@ -1,0 +1,43 @@
+import os
+from datetime import date
+
+from azure.identity import ClientSecretCredential
+from azure.mgmt.costmanagement import CostManagementClient
+
+
+def get_subscription_costs():
+    """Return cost data for the configured subscription."""
+    tenant_id = os.getenv("AZURE_TENANT_ID")
+    client_id = os.getenv("AZURE_CLIENT_ID")
+    client_secret = os.getenv("AZURE_CLIENT_SECRET")
+    subscription_id = os.getenv("AZURE_SUBSCRIPTION_ID")
+
+    if not all([tenant_id, client_id, client_secret, subscription_id]):
+        raise ValueError("Azure credentials are not fully configured")
+
+    credential = ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    cost_client = CostManagementClient(credential)
+
+    today = date.today()
+    start = today.replace(day=1)
+
+    query = {
+        "type": "ActualCost",
+        "timeframe": "Custom",
+        "timePeriod": {"from": start.isoformat(), "to": today.isoformat()},
+        "dataset": {
+            "granularity": "Daily",
+            "aggregation": {
+                "totalCost": {"name": "PreTaxCost", "function": "Sum"}
+            },
+        },
+    }
+
+    result = cost_client.query.usage(
+        scope=f"/subscriptions/{subscription_id}", parameters=query
+    )
+    return result.as_dict()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, HTTPException
+
+from .cost import get_subscription_costs
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Azure Cost Optimizer API"}
+
+
+@app.get("/costs")
+def read_costs():
+    """Retrieve basic cost information for the subscription."""
+    try:
+        return get_subscription_costs()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+This folder will contain the React application built with Vite.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,13 @@
+# Infrastructure
+
+This directory contains the Bicep templates used to deploy the Azure Cost Optimizer.
+
+## Deploying
+
+Use the Azure CLI to deploy `main.bicep` to your subscription:
+
+```bash
+az deployment group create \
+  --resource-group <resource-group> \
+  --template-file main.bicep
+```

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,22 @@
+param location string = resourceGroup().location
+param backendName string = 'cost-optimizer-api'
+param skuName string = 'B1'
+
+resource servicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+  name: 'cost-optimizer-plan'
+  location: location
+  sku: {
+    name: skuName
+    tier: 'Basic'
+  }
+}
+
+resource webApp 'Microsoft.Web/sites@2022-03-01' = {
+  name: backendName
+  location: location
+  serverFarmId: servicePlan.id
+  kind: 'app'
+  properties: {
+    httpsOnly: true
+  }
+}


### PR DESCRIPTION
## Summary
- set infrastructure directory to use Bicep
- document how to deploy Bicep templates
- add a simple App Service deployment in `main.bicep`

## Testing
- `pre-commit run --files README.md infra/main.bicep infra/README.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418d0ee3108325a3238157fc0a4e23